### PR TITLE
Feature/configurable ray head address for remote deployments

### DIFF
--- a/mlflow_ray_serve/__init__.py
+++ b/mlflow_ray_serve/__init__.py
@@ -73,7 +73,7 @@ class RayServePlugin(BaseDeploymentClient):
                 error_code=INVALID_PARAMETER_VALUE)
         self.client.create_backend(
             name, MLflowBackend, model_uri, config=config)
-        self.client.create_endpoint(name, backend=name)
+        self.client.create_endpoint(name, backend=name, route=("/" + name))
         return {"name": name, "config": config, "flavor": "python_function"}
 
     def delete_deployment(self, name):

--- a/mlflow_ray_serve/__init__.py
+++ b/mlflow_ray_serve/__init__.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import urllib.parse
 from typing import Optional, Tuple


### PR DESCRIPTION
This PR extends ray serve url format allowing read specific ray cluster head address that will be used for ray cluster connection. When remote address is provided, the `RayClient` will be used instead or `ray.init` method, allowing deployments out of cluster nodes.

Unfortunately, this will work only with nightly build. See [this thread.](https://discuss.ray.io/t/ray-serve-ray-client-attributeerror-clientobjectref-object-has-no-attribute-on-completed/1996) 