### PR TITLE
feat(http): expose mlflow models as http services

### DIFF
--- a/tests/test_mlflow_plugin.py
+++ b/tests/test_mlflow_plugin.py
@@ -1,11 +1,16 @@
+import os
 import shutil
 
 import mlflow.pyfunc
 import pandas as pd
+import requests
 from mlflow.deployments import get_deploy_client
 
 
 # Define the model class
+from mlflow.exceptions import MlflowException
+
+
 class AddN(mlflow.pyfunc.PythonModel):
     def __init__(self, n):
         self.n = n
@@ -15,20 +20,28 @@ class AddN(mlflow.pyfunc.PythonModel):
 
 
 # Construct and save the model
-model_path = "/Users/archit/mlflow-ray-serve/add_n_model"
-add5_model = AddN(n=5)
-mlflow.pyfunc.save_model(path=model_path, python_model=add5_model)
+model_path = os.path.abspath("models/add_n_model")
 
+try:
+    mlflow.pyfunc.save_model(path=model_path, python_model=AddN(n=5))
+except MlflowException as e:
+    pass
 # Evaluate the model
 client = get_deploy_client("ray-serve")
 
-client.create_deployment("add5", model_path)
+client.delete_deployment("add5")
+client.create_deployment("add5", model_uri=model_path)
 print(client.list_deployments())
 print(client.get_deployment("add5"))
 
 model_input = pd.DataFrame([range(10)])
+expected_output = pd.DataFrame([range(5, 15)])
 model_output = client.predict("add5", model_input)
-assert model_output.equals(pd.DataFrame([range(5, 15)]))
+assert model_output.equals(expected_output)
+
+response = requests.post("http://localhost:8000/add5", json=model_input.to_json())
+assert response.status_code == 200
+assert pd.read_json(response.content).equals(expected_output)
 
 client.delete_deployment("add5")
 shutil.rmtree(model_path)


### PR DESCRIPTION
This PR make models accepts http request with serialized json data that can be converted into a pandas DataFrame for model inference.

Closes #6 